### PR TITLE
Return release tokens error

### DIFF
--- a/src/api/contract/unlock.js
+++ b/src/api/contract/unlock.js
@@ -24,6 +24,8 @@ module.exports = async (efx, token, amount) => {
   if( Date.now() / 1000 < depositLock ) {
     const response = await efx.releaseTokens(token)
 
+    if(response.error) return response
+
     const sig = response.releaseSignature
 
     // push values into arguments array


### PR DESCRIPTION
Fix:

Release tokens fails in cases where there are open orders. This error should be returned when attempting to call unlock.