### PR TITLE
Add bignumber.js for calculating token amounts when generating orders

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "0x.js": "^0.38.4",
     "aware": "^0.3.1",
+    "bignumber.js": "^7.2.1",
     "bluebird": "^3.5.1",
     "del": "^3.0.0",
     "ethereumjs-util": "^5.2.0",

--- a/src/api/contract/create_order.js
+++ b/src/api/contract/create_order.js
@@ -17,15 +17,15 @@ module.exports = (efx, symbol, amount, price, validFor) => {
   let buyAmount, sellAmount
 
   if (amount > 0) {
-    buyAmount = (new BigNumber(10 ** buyCurrency.decimals)).times(amount)
-    sellAmount = (new BigNumber(10 ** sellCurrency.decimals)).times(amount).times(price)
+    buyAmount = (new BigNumber(10)).pow(buyCurrency.decimals).times(amount).integerValue(BigNumber.ROUND_FLOOR).toString()
+    sellAmount = (new BigNumber(10)).pow(sellCurrency.decimals).times(amount).times(price).integerValue(BigNumber.ROUND_FLOOR).toString()
 
     // console.log( "Buying " + amount + ' ' + buySymbol + " for: " + price + ' ' + sellSymbol )
   }
 
   if (amount < 0) {
-    buyAmount = (new BigNumber(10 ** buyCurrency.decimals)).times(amount).times(price).abs()
-    sellAmount = (new BigNumber(10 ** sellCurrency.decimals)).times(amount).abs()
+    buyAmount = (new BigNumber(10)).pow(buyCurrency.decimals).times(amount).times(price).abs().integerValue(BigNumber.ROUND_FLOOR).toString()
+    sellAmount = (new BigNumber(10)).pow(sellCurrency.decimals).times(amount).abs().integerValue(BigNumber.ROUND_FLOOR).toString()
 
     // console.log( "Selling " + Math.abs(amount) + ' ' + sellSymbol + " for: " + price + ' ' + buySymbol )
   }
@@ -45,13 +45,13 @@ module.exports = (efx, symbol, amount, price, validFor) => {
     maker: efx.get('account').toLowerCase(),
     makerFee: web3.utils.toBN('0'),
     makerTokenAddress: sellCurrency.wrapperAddress.toLowerCase(),
-    makerTokenAmount: sellAmount.toString(10),
+    makerTokenAmount: sellAmount,
 
     salt: ZeroEx.generatePseudoRandomSalt(),
     taker: efx.config['0x'].ethfinexAddress.toLowerCase(),
     takerFee: web3.utils.toBN('0'),
     takerTokenAddress: buyCurrency.wrapperAddress.toLowerCase(),
-    takerTokenAmount: buyAmount.toString(10),
+    takerTokenAmount: buyAmount,
 
     exchangeContractAddress: efx.config['0x'].exchangeAddress.toLowerCase()
   }

--- a/src/api/contract/create_order.js
+++ b/src/api/contract/create_order.js
@@ -1,4 +1,5 @@
 const {ZeroEx} = require('0x.js')
+const BigNumber = require('bignumber.js');
 
 module.exports = (efx, symbol, amount, price, validFor) => {
   const { web3, config } = efx
@@ -16,15 +17,15 @@ module.exports = (efx, symbol, amount, price, validFor) => {
   let buyAmount, sellAmount
 
   if (amount > 0) {
-    buyAmount = web3.utils.toBN(Math.trunc(10 ** buyCurrency.decimals * amount))
-    sellAmount = web3.utils.toBN(Math.trunc(10 ** sellCurrency.decimals * amount * price))
+    buyAmount = (new BigNumber(10 ** buyCurrency.decimals)).times(amount)
+    sellAmount = (new BigNumber(10 ** sellCurrency.decimals)).times(amount).times(price)
 
     // console.log( "Buying " + amount + ' ' + buySymbol + " for: " + price + ' ' + sellSymbol )
   }
 
   if (amount < 0) {
-    buyAmount = web3.utils.toBN(Math.trunc(10 ** buyCurrency.decimals * amount * price)).abs()
-    sellAmount = web3.utils.toBN(Math.trunc(10 ** sellCurrency.decimals * amount)).abs()
+    buyAmount = (new BigNumber(10 ** buyCurrency.decimals)).times(amount).times(price).abs()
+    sellAmount = (new BigNumber(10 ** sellCurrency.decimals)).times(amount).abs()
 
     // console.log( "Selling " + Math.abs(amount) + ' ' + sellSymbol + " for: " + price + ' ' + buySymbol )
   }

--- a/src/api/contract/lock.js
+++ b/src/api/contract/lock.js
@@ -1,3 +1,4 @@
+const BigNumber = require('bignumber.js');
 /**
  * Execute 'deposit' method on locker address
  *
@@ -7,7 +8,7 @@ module.exports = async (efx, token, amount, duration) => {
   const currency = efx.config['0x'].tokenRegistry[token]
 
   // value we sending to the lockerContract
-  const value = (amount * (10 ** currency.decimals)).toString(10)
+  const value = (new BigNumber(10)).pow(currency.decimals).times(amount).integerValue(BigNumber.ROUND_FLOOR).toString()
 
   const action = 'deposit'
 

--- a/src/api/contract/unlock.js
+++ b/src/api/contract/unlock.js
@@ -1,3 +1,4 @@
+const BigNumber = require('bignumber.js');
 /**
  * Call unlock method on wrapper contract
  */
@@ -5,7 +6,7 @@ module.exports = async (efx, token, amount, nonce, signature) => {
   const currency = efx.config['0x'].tokenRegistry[token]
 
   // value we asking to unlock
-  const value = (amount * (10 ** currency.decimals)).toString(10)
+  const value = (new BigNumber(10)).pow(currency.decimals).times(amount).integerValue(BigNumber.ROUND_FLOOR).toString()
 
   const action = 'withdraw'
 


### PR DESCRIPTION
This fixes edge-cases for creating orders with a large number of decimals when the token amounts are formated like "1e+21". 