### PR TITLE
0xV2 order testing preparation methods

### DIFF
--- a/src/api/contract/create_order_v2.js
+++ b/src/api/contract/create_order_v2.js
@@ -1,4 +1,5 @@
 const {assetDataUtils, generatePseudoRandomSalt} = require('@0xproject/order-utils')
+const BigNumber = require('bignumber.js');
 
 module.exports = (efx, symbol, amount, price, validFor) => {
   const { web3, config } = efx
@@ -16,21 +17,18 @@ module.exports = (efx, symbol, amount, price, validFor) => {
   let buyAmount, sellAmount
 
   if (amount > 0) {
-    buyAmount = web3.utils.toBN(Math.trunc(10 ** buyCurrency.decimals * amount))
-    sellAmount = web3.utils.toBN(Math.trunc(10 ** sellCurrency.decimals * amount * price))
+    buyAmount = (new BigNumber(10)).pow(buyCurrency.decimals).times(amount).integerValue(BigNumber.ROUND_FLOOR).toString()
+    sellAmount = (new BigNumber(10)).pow(sellCurrency.decimals).times(amount).times(price).integerValue(BigNumber.ROUND_FLOOR).toString()
 
     // console.log( "Buying " + amount + ' ' + buySymbol + " for: " + price + ' ' + sellSymbol )
   }
 
   if (amount < 0) {
-    buyAmount = web3.utils.toBN(Math.trunc(10 ** buyCurrency.decimals * amount * price)).abs()
-    sellAmount = web3.utils.toBN(Math.trunc(10 ** sellCurrency.decimals * amount)).abs()
+    buyAmount = (new BigNumber(10)).pow(buyCurrency.decimals).times(amount).times(price).abs().integerValue(BigNumber.ROUND_FLOOR).toString()
+    sellAmount = (new BigNumber(10)).pow(sellCurrency.decimals).times(amount).abs().integerValue(BigNumber.ROUND_FLOOR).toString()
 
     // console.log( "Selling " + Math.abs(amount) + ' ' + sellSymbol + " for: " + price + ' ' + buySymbol )
   }
-
-  // console.log( "   buy amount: " + buyAmount + " " + buySymbol )
-  // console.log( "  sell amount: " + sellAmount + " " + sellSymbol )
 
   let expiration
   expiration = Math.round((new Date()).getTime() / 1000)
@@ -44,9 +42,9 @@ module.exports = (efx, symbol, amount, price, validFor) => {
     feeRecipientAddress: efx.config['0x'].ethfinexAddress.toLowerCase(),
     senderAddress: efx.config['0x'].ethfinexAddress.toLowerCase(),
 
-    makerAssetAmount: sellAmount.toString(10),
+    makerAssetAmount: sellAmount,
 
-    takerAssetAmount: buyAmount.toString(10),
+    takerAssetAmount: buyAmount,
 
     makerFee: web3.utils.toBN('0').toString(10),
 
@@ -56,11 +54,11 @@ module.exports = (efx, symbol, amount, price, validFor) => {
 
     salt: generatePseudoRandomSalt(),
 
-    makerAssetData: assetDataUtils.encodeERC20AssetData(sellcurrency.wrapperAddress.toLowerCase()),
+    makerAssetData: assetDataUtils.encodeERC20AssetData(sellCurrency.wrapperAddress.toLowerCase()),
 
-    takerAssetData: assetDataUtils.encodeERC20AssetData(buycurrency.wrapperAddress.toLowerCase()),
+    takerAssetData: assetDataUtils.encodeERC20AssetData(buyCurrency.wrapperAddress.toLowerCase()),
 
-    exchangeAddress: config.exchangeContractAddress.toLowerCase(),
+    exchangeAddress: efx.config['0x'].exchangeAddress.toLowerCase()
   }
 
   return order

--- a/src/api/contract/create_order_v2.js
+++ b/src/api/contract/create_order_v2.js
@@ -52,7 +52,7 @@ module.exports = (efx, symbol, amount, price, validFor) => {
 
     expirationTimeSeconds: web3.utils.toBN(expiration).toString(10),
 
-    salt: generatePseudoRandomSalt(),
+    salt: generatePseudoRandomSalt().toString(10),
 
     makerAssetData: assetDataUtils.encodeERC20AssetData(sellCurrency.wrapperAddress.toLowerCase()),
 

--- a/src/api/sign/order_v2.js
+++ b/src/api/sign/order_v2.js
@@ -12,7 +12,7 @@ module.exports = async (efx, order) => {
     signerType
   )
 
-  // order.signature = signedOrder
+  order.signature = signature
 
   /**
   const isValid = ZeroEx.isValidSignature(orderHash, signedOrder, efx.get('account').toLowerCase())
@@ -20,5 +20,5 @@ module.exports = async (efx, order) => {
   console.log( "is_valid ->", isValid)
   **/
 
-  return signature
+  return order
 }

--- a/src/api/submit_order_v2.js
+++ b/src/api/submit_order_v2.js
@@ -1,0 +1,39 @@
+const {post} = require('request-promise')
+const parse = require('../lib/parse/response/submit_order')
+
+module.exports = async (efx, symbol, amount, price, gid, cid, signedOrder, validFor) => {
+  if (!(symbol && amount && price)) {
+    throw new Error('order, symbol, amount and price are required')
+  }
+
+  //TODO: check if symbol is a valid symbol
+
+  if(!signedOrder){
+    const order = efx.contract.createOrderV2(symbol, amount, price, validFor)
+
+    signedOrder = await efx.sign.orderV2(order)
+  }
+
+  const meta = signedOrder
+
+  const type = 'EXCHANGE LIMIT'
+
+  const protocol = '0x2'
+
+  symbol = 't' + symbol
+
+  const data = {
+    gid,
+    cid,
+    type,
+    symbol,
+    amount,
+    price,
+    meta,
+    protocol
+  }
+
+  const url = efx.config.api + '/w/on'
+
+  return parse(post(url, {json: data}))
+}

--- a/src/api/submit_order_v2.js
+++ b/src/api/submit_order_v2.js
@@ -18,7 +18,7 @@ module.exports = async (efx, symbol, amount, price, gid, cid, signedOrder, valid
 
   const type = 'EXCHANGE LIMIT'
 
-  const protocol = '0x2'
+  const protocol = '0x'
 
   symbol = 't' + symbol
 

--- a/src/lib/bind_api.js
+++ b/src/lib/bind_api.js
@@ -33,6 +33,7 @@ module.exports = () => {
     locked: compose(require('../api/contract/locked')),
     unlock: compose(require('../api/contract/unlock')),
     createOrder: compose(require('../api/contract/create_order')),
+    createOrderV2: compose(require('../api/contract/create_order_v2')),
     abi: {
       locker: require('../api/contract/abi/locker.abi.js'),
       token: require('../api/contract/abi/token.abi.js')
@@ -50,6 +51,7 @@ module.exports = () => {
   efx.sign = compose(require('../api/sign/sign'))
   // hack to get a nice method signature
   efx.sign.order = compose(require('../api/sign/order'))
+    efx.sign.orderV2 = compose(require('../api/sign/order_v2'))
   efx.sign.cancelOrder = compose(require('../api/sign/cancel_order'))
   efx.sign.request = compose(require('../api/sign/request'))
 
@@ -61,6 +63,7 @@ module.exports = () => {
   efx.getOrdersHist = compose(require('../api/get_orders_hist'))
   efx.releaseTokens = compose(require('../api/release_tokens'))
   efx.submitOrder = compose(require('../api/submit_order'))
+  efx.submitOrderV2 = compose(require('../api/submit_order_v2'))
   efx.submitBuyOrder = compose(require('../api/submit_buy_order'))
   efx.submitSellOrder = compose(require('../api/submit_sell_order'))
 


### PR DESCRIPTION
This adds methods to prepare orders in the format required for Ethfinex using the official 0x version 2 contracts. 

Order protocol will likely be differentiated when submitting orders to: `api.ethfinex.com/trustless/v1/w/on` 
using `protocol = '0x2'` as opposed to `protocol = '0x'` as is set currently.